### PR TITLE
added subnet for helium network to prevent conflicts with VPN

### DIFF
--- a/roles/miner/templates/docker-compose.yml
+++ b/roles/miner/templates/docker-compose.yml
@@ -119,4 +119,7 @@ volumes:
 
 networks:
   helium:
-
+   driver: bridge
+   ipam:
+    config:
+     - subnet: 172.16.57.0/24


### PR DESCRIPTION
I was running into this issue. This patch seems to fix it.

https://stackoverflow.com/questions/43720339/docker-error-could-not-find-an-available-non-overlapping-ipv4-address-pool-am

