### PR TITLE
Provide inventory example for both regions

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -1,10 +1,8 @@
 all:
   children:
     eu868:
-    hotspot:
       hosts: 
-        myminer:
-          ansible_host: 20.0.0.14 
+        hotspot:
+          ansible_host: 192.168.1.14
           ansible_user: pi
-          #ansible_become_pass: raspberry
           ansible_become: true


### PR DESCRIPTION
There's two examples, one for EU868 miners and another for US915 miners, both are commented, user needs to adapt to their own specific scenario.
Also fixed identation on the previous example