### PR TITLE
fix: variable in register rename

### DIFF
--- a/roles/miner/tasks/grafana-agent.yml
+++ b/roles/miner/tasks/grafana-agent.yml
@@ -13,9 +13,9 @@
     owner: pi
     group: pi
     mode: 0644
-  register: grafana-agent-config
+  register: grafana_agent_config
 
 - name: docker restart grafana-agent
   ansible.builtin.shell: docker restart grafana-agent
-  when: grafana-agent-config.changed
+  when: grafana_agent_config.changed
 


### PR DESCRIPTION
Fixes:
```
TASK [miner : template out /home/pi/grafana-agent/agent.yml] *********************************************************************************************************************************************
fatal: [hotspot]: FAILED! => {"msg": "Invalid variable name in 'register' specified: 'grafana-agent-config'"}
```
[Reference](https://stackoverflow.com/questions/38652148/ansible-playbook-make-sure-your-variable-name-does-not-contain-invalid-chara/41615364)
