### PR TITLE
feat: add log_only_failed to helium workarounds

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -6,6 +6,8 @@ seed_peer: "/p2p/11hVUgp5hMrZhCKcbamRUL1RnDxbEdpDVytSZsiGSkjRJxbujwa"
 enable_packet_forwarder: True
 target_pf_image: "ghcr.io/heliumdiy/sx1302_hal" # heliumdiy/sx1302_hal on docker hub
 target_pf_tag: "0.0.3"
+# Helium Workarounds
+workarounds_log_only_failed: True
 #Loki & Prometheus
 enable_node_exporter: False
 enable_grafana_agent: True

--- a/roles/miner/tasks/docker.yml
+++ b/roles/miner/tasks/docker.yml
@@ -17,3 +17,8 @@
     name: "update miner"
     minute: "*/30"
     job: "docker-compose -f /home/pi/docker-compose.yml pull miner && docker-compose -f /home/pi/docker-compose.yml ps -q miner && docker-compose -f /home/pi/docker-compose.yml up -d miner"
+- name: cron job to update helum_workarounds
+  ansible.builtin.cron:
+    name: "update workarounds"
+    minute: "*/30"
+    job: "docker-compose -f /home/pi/docker-compose.yml pull helium_workarounds && docker-compose -f /home/pi/docker-compose.yml ps -q helium_workarounds && docker-compose -f /home/pi/docker-compose.yml up -d helium_workarounds"

--- a/roles/miner/tasks/docker.yml
+++ b/roles/miner/tasks/docker.yml
@@ -17,7 +17,7 @@
     name: "update miner"
     minute: "*/30"
     job: "docker-compose -f /home/pi/docker-compose.yml pull miner && docker-compose -f /home/pi/docker-compose.yml ps -q miner && docker-compose -f /home/pi/docker-compose.yml up -d miner"
-- name: cron job to update helum_workarounds
+- name: cron job to update helium_workarounds
   ansible.builtin.cron:
     name: "update workarounds"
     minute: "*/30"

--- a/roles/miner/templates/docker-compose.yml
+++ b/roles/miner/templates/docker-compose.yml
@@ -127,6 +127,8 @@ services:
     volumes:
       - /home/pi/miner_data/log:/log
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - LOG_ONLY_FAILED={{ workarounds_log_only_failed }}
     networks:
       - helium
     restart: unless-stopped


### PR DESCRIPTION
Log only failed events for helium workarounds container, option set to true by default