### PR TITLE
feat: install python3-pip

### DIFF
--- a/roles/rpi/tasks/software.yml
+++ b/roles/rpi/tasks/software.yml
@@ -14,6 +14,7 @@
       - neovim
       - locales-all
       - neofetch
+      - python3-pip
       - jq # JSON cli processor for Height Helper
       - bc # Basic Calculator for Height Helper
 - name: install docker dependancies


### PR DESCRIPTION
Noticed on a new deployment that pip3 was missing.